### PR TITLE
Using //domain/file.extension is an antipattern.

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
     <meta name="format-detection" content="address=no" />   
     <link rel="shortcut icon" href="/images/favicon.png" />
     <link rel="stylesheet" type="text/css" href="/css/style.css" />
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script type="text/javascript" src="/js/jquery.touchwipe.js"></script>
     <script type="text/javascript" src="/js/script.js"></script>
-    <script type="text/javascript" src="//assets.gfycat.com/js/gfyajax-0.517d.js"></script>
+    <script type="text/javascript" src="https://assets.gfycat.com/js/gfyajax-0.517d.js"></script>
     <script type="text/javascript">
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-4533496-15']);


### PR DESCRIPTION
If HTTPS is not available, a non-protocol url should not be used.
If HTTPS is available, using it 100% of the time hurts no one.
Plus, this makes the scripts load correctly when using the `file://` protocol to view the file locally.

Plus plus, Paul Irish said so http://www.paulirish.com/2010/the-protocol-relative-url/