### PR TITLE
Prefer gifv(webm) for imgur and swap mp4/webm for gfycat. redditp is now much faster!

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -507,21 +507,40 @@ $(function () {
     //
     var slideBackgroundPhoto = function (imageIndex) {
 
+
         // Retrieve the accompanying photo based on the index
         var photo = rp.photos[imageIndex];
 
         // Create a new div and apply the CSS
-        var cssMap = Object();
-        cssMap['display'] = "none";
+        var divNode = $("<div />")
         if(!photo.isVideo) {
-            cssMap['background-image'] = "url(" + photo.url + ")";
-            cssMap['background-repeat'] = "no-repeat";
-            cssMap['background-size'] = "contain";
-            cssMap['background-position'] = "center";
+           
+            if(photo.url.search(/^http.*imgur.*gif$/) > -1) {
+               // prefer gifv over gif
+               photo.url = photo.url.replace(/.gif$/, '.webm')
+
+               var videoTagStr  = '<video autoplay loop poster="true" width="100%" height="100%">'
+                   videoTagStr += '  <source src="' + photo.url + '" type="video/webm">'
+                   videoTagStr += '</video>'
+
+               divNode.append(videoTagStr)
+            
+            }
+            else {
+              var cssMap = Object();
+              cssMap['display'] = "none";
+              cssMap['background-image'] = "url(" + photo.url + ")";
+              cssMap['background-repeat'] = "no-repeat";
+              cssMap['background-size'] = "contain";
+              cssMap['background-position'] = "center";
+
+              divNode.css(cssMap).addClass("clouds");
+            
+            }
+              
         }
 
-        //var imgNode = $("<img />").attr("src", photo.image).css({opacity:"0", width: "100%", height:"100%"});
-        var divNode = $("<div />").css(cssMap).addClass("clouds");
+
         if(photo.isVideo) {
             clearTimeout(nextSlideTimeoutId);
             var gfyid = photo.url.substr(1 + photo.url.lastIndexOf('/'));

--- a/js/script.js
+++ b/js/script.js
@@ -543,6 +543,10 @@ $(function () {
                     vid.find('.gfyPreLoadCanvas').remove();
                     var v = vid.find('video').width('100%').height('100%');
                     vid.find('.gfyPreLoadCanvas').remove();
+
+                    // swap mp4 and webm, so that browsers prefer webm
+                    v.first().find('.webmsource').after(v.first().find('.mp4source'))
+
                     if (shouldAutoNextSlide)
                         v.removeAttr('loop');
                     v[0].onended = function (e) {


### PR DESCRIPTION
A while back I created issue #31 ([reddit](https://www.reddit.com/r/redditp/comments/3bhc5c/link_to_webm_instead_of_mp4_for/)) trying to figure out how to make redditp faster when dealing with gifs.

I got some time today so I went ahead and fixed it. There are 2 things in the PR (see commits)

- link to gifv (webm) instead of gif for imgur
- swap mp4 and webm inside the `<video>` for gfycat. Browsers render the first recognizable format, and unfortunately that was mp4 (fat). With this change, it is webm (lean)

Let me know if you have questions,

Cheers!
Jeff