### PR TITLE
Skip rmoved images plus some fixup

### DIFF
--- a/js/EmbedIt.js
+++ b/js/EmbedIt.js
@@ -6,7 +6,7 @@ embedit.video = function (webmUrl, mp4Url) {
     // video. We can only circumvent that by putting the src 
     // on the <video> tag :/
     
-    var video = $('<video autoplay loop poster="true" />');
+    var video = $('<video autoplay loop/>');
     video.append($('<source/>').attr('src', webmUrl));
     video.append($('<source/>').attr('src', mp4Url));
     return video;

--- a/js/script.js
+++ b/js/script.js
@@ -727,6 +727,7 @@ $(function () {
             // NOTE: if data.data.after is null then this causes us to start
             // from the top on the next getRedditImages which is fine.
             rp.session.after = "&after=" + data.data.after;
+            var nextIndex = rp.photos.length;
 
             if (data.data.children.length === 0) {
                 toastr.error("No data from this url :(");
@@ -765,6 +766,7 @@ $(function () {
                 addNumberButton(numberButton);
             }
             rp.session.loadingNextImages = false;
+            preLoadImages(rp.photos[nextIndex].url, rp.photos[nextIndex]);
             
         };
 

--- a/js/script.js
+++ b/js/script.js
@@ -35,6 +35,8 @@ rp.session = {
     after: "",
 
     foundOneImage: false,
+    
+    noMorePictures: false,
 
     loadingNextImages: false
 };
@@ -94,7 +96,7 @@ $(function () {
                 return i;
             }
         }
-        if (isLastImage(getNextSlideIndex) && !rp.session.loadingNextImages) {
+        if (rp.session.noMorePictures && !rp.session.loadingNextImages) {
             // The only reason we got here and there aren't more pictures yet
             // is because there are no more images to load, start over
             return 0;
@@ -764,6 +766,7 @@ $(function () {
                 // Show the user we're starting from the top
                 var numberButton = $("<span />").addClass("numberButton").text("-");
                 addNumberButton(numberButton);
+                rp.session.noMorePictures = true;
             }
             rp.session.loadingNextImages = false;
             preLoadImages(rp.photos[nextIndex].url, rp.photos[nextIndex]);


### PR DESCRIPTION
- Automaticly skip removed imgur images.
  Images compared to known dimensions, and skipped if matched.
- Fixed
- looping, when there is no more images.
- Preload next image from freshly loaded batch.
- Fixed GET request to /true url (incorrect usage of poster tag)
