### PR TITLE
Enable .play() to be executed on mobile devices

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -612,6 +612,10 @@ $(function () {
         } else if(photo.type === imageTypes.gfycat || photo.type === imageTypes.gifv) {
             embedit.embed(photo.url, function(elem) {
                 divNode.append(elem);
+                $(elem).attr({
+                    muted: '',
+                    playsinline: '',
+                });
                 elem.width('100%').height('100%');
                 // We start paused and play after the fade in.
                 // This is to avoid cached or preloaded videos from playing.


### PR DESCRIPTION
Autoplay is now permitted by Chrome and Safari by adding a "muted" attribute to the video.
See: https://developers.google.com/web/updates/2016/07/autoplay

Also added `playsinline` to allow video to be played inline for iOS >= 10 devices
See: https://webkit.org/blog/6784/new-video-policies-for-ios/