### PR TITLE
Fix that f---ing "data.gfyItem is undefined" error

### DIFF
--- a/js/EmbedIt.js
+++ b/js/EmbedIt.js
@@ -83,9 +83,9 @@ embedit.convertors = [
         detect: /gfycat\.com.*/,
         convert: function (url, embedFunc) {
             //https://gfycat.com/cajax/get/ScaryGrizzledComet
-            var match = url.match(/gfycat.com\/(\w+)/i);
-            if(match && match.length > 1)
-                var name = match[1];
+            var match = url.match(/gfycat.com\/(gifs\/detail\/)?(\w+)/i);
+            if(match && match.length > 2)
+                var name = match[2];
             else
                 return false;
             


### PR DESCRIPTION
It's been bugging me for ages, I'm pretty sure this commit fixes it immediately (I just allow an extra `gifs/detail/` to appear in the URL without affecting the name). I haven't been able to test, but the change only affects 3 lines in a way that can be worked out in one's head; I recommend checking to be sure, of course.