### PR TITLE
Added history / back button support.

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -487,6 +487,7 @@ $(function () {
 
     // History / back button stuff
     var lastSavedHistoryState = {index: -1, url: ""};
+    var scheduledAnimation = null;
 
     var loadHistory = function(state) {
         //console.log("Loading history state " + event.state);
@@ -500,30 +501,42 @@ $(function () {
         }
 
         startAnimation(index);
-    }
+    };
 
     window.onpopstate = function(event) {
         // This is called when back/forward button is pressed and there is custom history states saved.
         loadHistory(event.state);
     };
 
-    function saveHistory(index) {
+    var saveHistory = function(index) {
+        if (window.history == null) {
+            return; // History api is not supported, do nothing
+        }
+
         var photo = rp.photos[index];
         if (index != lastSavedHistoryState.index && photo != null) {
             //console.log("Recorded history state " + index);
             lastSavedHistoryState = {index: index, url: photo.url};
             history.pushState(lastSavedHistoryState, photo.title);
         }
-    }
+    };
 
-    var scheduledAnimation;
     var animationFinished = function() {
         if (scheduledAnimation != null) {
             var next = scheduledAnimation;
             scheduledAnimation = null;
             startAnimation(next);
         }
-    }
+    };
+
+    var showDefault = function() {
+        // What to show initially
+        if (window.history != null) {
+            loadHistory(history.state);
+        } else {
+            startAnimation(0);
+        }
+    };
 
     //
     // Starts the animation, based on the image index
@@ -872,7 +885,7 @@ $(function () {
 
             // show the first image
             if (rp.session.activeIndex == -1) {
-                loadHistory(history.state);
+                showDefault();
             }
 
             if (data.data.after == null) {
@@ -936,7 +949,7 @@ $(function () {
 
             // show the first image
             if (rp.session.activeIndex == -1) {
-                loadHistory(history.state);
+                showDefault();
             }
 
             //log("No more pages to load from this subreddit, reloading the start");


### PR DESCRIPTION
I implemented back button and history support just for kicks (as discussed on #77). Feel free to merge it or not at your own pleasure.

I tried to break it but it seems to work pretty ok. There is a small 1 item queue for animations, so when you frantically hit back button many times you end up on the same pic you're supposed to even with animations running.

There are some edge cases like going to the slideshow, then going a lot of images further, then going via a link to external site and returning to redditp via back (so the image is no longer loaded or the image with the same index might be wrong), but these cases should just throw you to the start of the slideshow as before.

I suggest you give it a spin, for me it increases usability dramatically.