### PR TITLE
Added animation settings

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -134,3 +134,7 @@ label.checkbox { font-weight: bold; }
     height: 100%;
     cursor: pointer;
 }
+
+#animationSpeed {
+    width: 50px;
+}

--- a/index.html
+++ b/index.html
@@ -106,6 +106,16 @@
             </ul>
             <ul class="nbmenu">
                 <li>
+                    <input class="checkbox" type="checkbox" name="animationsEnabled" id="animationsEnabled" value="animation" checked />
+                    <label class="checkbox" for="animationsEnabled"> Animations</label>
+                </li>
+                <li>
+                    <label for="animationSpeed">Speed:</label>
+                    <input type="number" name="animationSpeed" id="animationSpeed" value="1000" min="250"> ms
+                </li>
+            </ul>
+            <ul class="nbmenu">
+                <li>
                     <input class="checkbox" type="checkbox" name="autoNextSlide" id="autoNextSlide" value="Auto" checked />
                     <label class="checkbox" for="autoNextSlide"> Auto-next</label>
                     every <input type="text" name="timeToNextSlide" id="timeToNextSlide" value="5" size="2" /> seconds

--- a/js/script.js
+++ b/js/script.js
@@ -11,6 +11,7 @@ var rp = {};
 
 rp.settings = {
     debug: true,
+    animationsEnabled: true,
     // Speed of the animation
     animationSpeed: 1000,
     shouldAutoNextSlide: true,
@@ -194,7 +195,9 @@ $(function () {
     var cookieNames = {
         nsfwCookie: "nsfwCookie",
         shouldAutoNextSlideCookie: "shouldAutoNextSlideCookie",
-        timeToNextSlideCookie: "timeToNextSlideCookie"
+        timeToNextSlideCookie: "timeToNextSlideCookie",
+        animationsEnabledCookie: "animationsEnabledCookie",
+        animationSpeedCookie: "animationSpeedCookie"
     };
 
     var setCookie = function (c_name, value) {
@@ -205,6 +208,16 @@ $(function () {
     var getCookie = function (c_name) {
         // undefined in case nothing found
         return Cookies.get(c_name);
+    };
+    
+    var animationSpeedChange = function() {
+        rp.settings.animationSpeed = parseInt($("#animationSpeed").val());
+        setCookie(cookieNames.animationSpeedCookie, rp.settings.animationSpeed);
+    };
+
+    var toggleAnimations = function () {
+        rp.settings.animationsEnabled = $("#animationsEnabled").is(':checked');
+        setCookie(cookieNames.animationsEnabledCookie, rp.settings.animationsEnabled);
     };
 
     var resetNextSlideTimer = function () {
@@ -281,6 +294,28 @@ $(function () {
             rp.settings.timeToNextSlide = parseFloat(timeByCookie) * 1000;
             $('#timeToNextSlide').val(timeByCookie);
         }
+
+        // Enable/Disable animations
+        var animationsEnabledCookie = getCookie(cookieNames.animationsEnabledCookie);
+        if (animationsEnabledCookie === undefined) {
+            var isEnabled = $("#animationsEnabled").is(":checked");
+            rp.settings.animationsEnabled = isEnabled;
+        } else {
+            rp.settings.animationsEnabled = (animationsEnabledCookie === "true");
+            $("#animationsEnabled").prop("checked", rp.settings.animationsEnabled);
+        }
+        $("#animationsEnabled").change(toggleAnimations);
+
+        // Set animation speed
+        var animationSpeedCookie = getCookie(cookieNames.animationSpeedCookie);
+        if (animationSpeedCookie === undefined) {
+            var speed = parseInt($("#animationSpeed").val());
+            rp.settings.animationSpeed = speed;
+        } else {
+            rp.settings.animationSpeed = parseInt(animationSpeedCookie);
+            $("#animationSpeed").val(animationSpeedCookie);
+        }
+        $("#animationSpeed").on("input", animationSpeedChange);
         
         $('#fullScreenButton').click(toggleFullScreen);
 
@@ -604,17 +639,34 @@ $(function () {
         }
 
         divNode.prependTo(pictureSliderId);
-        $(pictureSliderId + " div").fadeIn(rp.settings.animationSpeed);
+
+        var newDiv = $(pictureSliderId + " div");
         var oldDiv = $(pictureSliderId + " div:not(:first)");
-        oldDiv.fadeOut(rp.settings.animationSpeed, function () {
+
+        var afterFadeOut = function() {
             oldDiv.remove();
             rp.session.isAnimating = false;
-            
+
+            // FIXME: Playing the video after the animation doesn't work
+            // if the animation speed is too fast (e.g. 50ms). Apparently
+            // the video element doens't load fast enough.
+            // The minimum animation speed is set to 250ms via the HTML element
+            // for now (<input type="number" min="250" ...>)
             var maybeVid = $('video');
             if(maybeVid.length > 0) {
                 startPlayingVideo(maybeVid);
             }
-        });
+        };
+
+        if (rp.settings.animationsEnabled == true) {
+            newDiv.fadeIn(rp.settings.animationSpeed);
+            oldDiv.fadeOut(rp.settings.animationSpeed, afterFadeOut);
+        } else {
+            newDiv.show();
+            oldDiv.hide();
+
+            afterFadeOut();
+        }
     }
     
     var createDiv = function(imageIndex) {
@@ -653,9 +705,13 @@ $(function () {
                     playsinline: '',
                 });
                 elem.width('100%').height('100%');
-                // We start paused and play after the fade in.
-                // This is to avoid cached or preloaded videos from playing.
-                elem[0].pause();
+
+                // Only pause video if animations are enabled
+                if (rp.settings.animationsEnabled) {
+                    // We start paused and play after the fade in.
+                    // This is to avoid cached or preloaded videos from playing.
+                    elem[0].pause();
+                }
             });
         }// else {
         //    reportError('Unhandled image type');


### PR DESCRIPTION
Added an option for enabling/disabling the animations as well as changing the speed of the animations (#86).

If the animation speed is too fast (e.g. 50ms) and you go back to the previous slide, it seems that the video elements don't load fast enough to invoke the `.play()` method on them (see [line 650](https://github.com/Merlin-CK/redditp/blob/189167f70d8ce51a7124d4b45b7e229d08490afb/js/script.js#L650)).

Other than that it works just fine.