### PR TITLE
Fixing bug with encodedString is undefined

### DIFF
--- a/js/EmbedIt.js
+++ b/js/EmbedIt.js
@@ -355,7 +355,12 @@ embedit.transformRedditData = function(pic) {
         console.log("GOTCHA!");
         if (pic.data.gallery_data && pic.data.gallery_data.items) {
             var firstItemId = pic.data.gallery_data.items[0].media_id;
-            pic.url = decodeEntities(pic.data.media_metadata[firstItemId]["s"]["u"]);
+            var encodedUrl = pic.data.media_metadata[firstItemId]["s"]["u"];
+            if (encodedUrl === undefined) {
+                // some posts don't have the u key, but have gif and mp4 keys
+                encodedUrl = pic.data.media_metadata[firstItemId]["s"]["mp4"];
+            }
+            pic.url = decodeEntities(encodedUrl);
             pic.type = embedit.imageTypes.image;
         }
         console.log(pic.url)

--- a/js/EmbedIt.js
+++ b/js/EmbedIt.js
@@ -358,7 +358,7 @@ embedit.transformRedditData = function(pic) {
             var encodedUrl = pic.data.media_metadata[firstItemId]["s"]["u"];
             if (encodedUrl === undefined) {
                 // some posts don't have the u key, but have gif and mp4 keys
-                encodedUrl = pic.data.media_metadata[firstItemId]["s"]["mp4"];
+                encodedUrl = pic.data.media_metadata[firstItemId]["s"]["gif"];
             }
             pic.url = decodeEntities(encodedUrl);
             pic.type = embedit.imageTypes.image;

--- a/js/EmbedIt.js
+++ b/js/EmbedIt.js
@@ -189,6 +189,14 @@ embedit.convertors = [
             return true;
         }
     },
+    {
+        name: "preview.redd.it",
+        detect: /preview\.redd\.it.*/,
+        convert: function (url, embedFunc) {
+            embedFunc(embedit.video(url));
+            return true;
+		}
+    }
 
 ]
 
@@ -356,12 +364,13 @@ embedit.transformRedditData = function(pic) {
         if (pic.data.gallery_data && pic.data.gallery_data.items) {
             var firstItemId = pic.data.gallery_data.items[0].media_id;
             var encodedUrl = pic.data.media_metadata[firstItemId]["s"]["u"];
+            pic.type = embedit.imageTypes.image;
             if (encodedUrl === undefined) {
                 // some posts don't have the u key, but have gif and mp4 keys
-                encodedUrl = pic.data.media_metadata[firstItemId]["s"]["gif"];
+                encodedUrl = pic.data.media_metadata[firstItemId]["s"]["mp4"];
+                pic.type = embedit.imageTypes.gifv;
             }
             pic.url = decodeEntities(encodedUrl);
-            pic.type = embedit.imageTypes.image;
         }
         console.log(pic.url)
     } else if (isImageExtension(pic.url)) {


### PR DESCRIPTION
I was browsing some nsfw subreddits when redditp reached a brick wall of sorts and didn't allow me to see any further images. A toast notification popped up stating "Redditp booboo: TypeError: encodedString is undefined"

After some digging, I believe to have found the underlying issue. Seaching for encodedString leads me to the decodeEntities function in Embedit.js, which is called with a reference to the Reddit JSON data. If the metadata doesn't contain an "u" key, the script ends up failing because undefined is passed as an argument and it breaks at the return of decodeEntities.

Checking the JSON of the subreddit in cause made me notice some keys (namely, "mp4" and "gif") that could probably be used for the same purpose as the "u" key so I coded this fix in relation to that. Haven't been able to test this though. Also, this doesn't guarantee that the script doesn't break if it finds something else that it doesn't understand/find.