### PR TITLE
Let browsers know that the input in here is numeric

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
                     <input class="checkbox" type="checkbox" name="autoNextSlide" id="autoNextSlide" value="Auto"
                         checked />
                     <label class="checkbox" for="autoNextSlide"> Auto-next</label>
-                    every <input type="text" name="timeToNextSlide" id="timeToNextSlide" value="5" size="2" /> seconds
+                    every <input type="text" name="timeToNextSlide" id="timeToNextSlide" inputmode="numeric" value="5" size="2" /> seconds
                 </li>
                 <li>
                     <input class="checkbox" type="checkbox" name="nsfw" id="nsfw" value="Auto" checked />


### PR DESCRIPTION
When changing this value on mobile, it shows a regular keyboard. When using "input type=number" it shows a nice numeric keyboard on Mobile, but on desktop it changes into a weird unstyled text with up and down buttons, which takes up waay too much space. Adding an inputmode=numeric is a nice way to have the great "input type=text" behavior on desktop, but signals to the (mobile) browser that a number is expected, so a numeric keyboard is shown.

See https://css-tricks.com/finger-friendly-numerical-inputs-with-inputmode/