### PR TITLE
makes prev and next buttons larger

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -107,9 +107,9 @@ label.checkbox { font-weight: bold; }
     width: 0; 
     height: 0; 
     
-    border-top: 15px solid transparent;
-    border-bottom: 15px solid transparent; 
-    border-right: 30px solid white; 
+    border-top: 25px solid transparent;
+    border-bottom: 25px solid transparent; 
+    border-right: 50px solid white; 
 	z-index:2;
     opacity: 0.8;
     
@@ -123,9 +123,9 @@ label.checkbox { font-weight: bold; }
     width: 0; 
     height: 0; 
     
-    border-top: 15px solid transparent;
-    border-bottom: 15px solid transparent; 
-    border-left: 30px solid white; 
+    border-top: 25px solid transparent;
+    border-bottom: 25px solid transparent; 
+    border-left: 50px solid white; 
     z-index:2;
     opacity: 0.8;
     cursor: hand; cursor: pointer;


### PR DESCRIPTION
When using mobile, it's next to impossible to hit the prev/next buttons at their current size. This becomes an issue now that some video providers open in a new tab if you tap anywhere other than the redditp ui elements. 

This commit makes the buttons slightly larger which should results is easier hits.

See issue #155 