### PR TITLE
Support Ctrl+C/Command+C for copying the current URL to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ http://redditp.com
 * u - open user slideshow in new tab
 * f - toggle full screen mode
 * m - toggle sound
+* Ctrl+C/Cmd+C - copy image URL to clipboard
 * Arrow keys, pgup/pgdown, spacebar change slides
 * Swipe gestures on phones
 

--- a/js/script.js
+++ b/js/script.js
@@ -153,6 +153,13 @@ $(function () {
         }
     }
 
+    function copy_to_clipboard(selector) {
+        var link = $(selector)[0];
+        navigator.clipboard.writeText(link.href).then(() => {
+            toastr.info("Copied URL to clipboard.", "", {timeOut: 100});
+        });
+    }
+
     $("#pictureSlider").touchwipe({
         // wipeLeft means the user moved his finger from right to left.
         wipeLeft: nextSlide,
@@ -421,7 +428,12 @@ $(function () {
 
     // Register keyboard events on the whole document
     $(document).keyup(function (e) {
-        if (e.ctrlKey) {
+        var code = (e.keyCode ? e.keyCode : e.which);
+        if (e.ctrlKey || e.metaKey) {
+            // Handle {Ctrl,Cmd}+C to copy image link.
+            if (code == C_KEY) {
+                copy_to_clipboard("#navboxLink");
+            }
             // ctrl key is pressed so we're most likely switching tabs or doing something
             // unrelated to redditp UI
             return;
@@ -435,8 +447,7 @@ $(function () {
         // 40 - down
         // More info: http://stackoverflow.com/questions/302122/jquery-event-keypress-which-key-was-pressed
         // http://stackoverflow.com/questions/1402698/binding-arrow-keys-in-js-jquery
-        var code = (e.keyCode ? e.keyCode : e.which);
-
+        
         switch (code) {
             case C_KEY:
                 $('#controlsDiv .collapser').click();


### PR DESCRIPTION
First of all, thanks for creating this project! I use it regularly for browsing through image subreddits to find things to share with friends. That usually involves me pressing 'i' to open the image in a new tab, then copying the image URL (which now involves using the context menu for Reddit) so I can paste it into a Discord channel. I wanted something simpler so I added support for handling Ctrl+C / Command+C to copy the current URL to the clipboard.

I was not sufficiently motivated to check the browser platform so as to handle the correct keyboard shortcut per platform. That wouldn't be much additional work, though.

An alternate approach would be to handle the [copy event](https://developer.mozilla.org/en-US/docs/Web/API/Element/copy_event) and set the clipboard data there. I'm not sure there'd be much functional difference, except that the browser would handle the keyboard shortcuts for us.
