### PR TITLE
Proper RedGIFs Sound Controls with Userscript

### DIFF
--- a/js/EmbedIt.js
+++ b/js/EmbedIt.js
@@ -73,7 +73,7 @@ embedit.redGifConvert = function (url, embedFunc) {
   // https://github.com/ubershmekel/redditp/issues/138
   // Redgifs isn't allowing CORS requests to others.
   // access-control-allow-origin: https://www.redgifs.com
-  const iframeUrl = 'https://www.redgifs.com/ifr/' + name;
+  const iframeUrl = 'https://www.redgifs.com/ifr/' + name + (rp.settings.sound ? "#sound" : "");
   embedFunc($('<iframe src="' + iframeUrl + '" frameborder="0" scrolling="no" width="100%" height="100%" allowfullscreen="" style="position:absolute;"></iframe>'));
   return true;
 };

--- a/js/EmbedIt.js
+++ b/js/EmbedIt.js
@@ -73,8 +73,8 @@ embedit.redGifConvert = function (url, embedFunc) {
   // https://github.com/ubershmekel/redditp/issues/138
   // Redgifs isn't allowing CORS requests to others.
   // access-control-allow-origin: https://www.redgifs.com
-  const iframeUrl = 'https://www.redgifs.com/ifr/' + "?link=false&loop=" + !rp.settings.shouldAutoNextSlide + "&sound=" + rp.settings.sound;
-  embedFunc($('<iframe src="' + iframeUrl + '" frameborder="0" scrolling="no" width="100%" height="100%" allowfullscreen="" style="position:absolute;"></iframe>'));
+  const iframeUrl = 'https://www.redgifs.com/ifr/' + name + "?link=false&loop=" + !rp.settings.shouldAutoNextSlide + "&sound=" + rp.settings.sound;
+  embedFunc($('<iframe class="gfyframe" src="' + iframeUrl + '" frameborder="0" scrolling="no" width="100%" height="100%" allowfullscreen="" style="position:absolute;"></iframe>'));
   return true;
 };
 

--- a/js/EmbedIt.js
+++ b/js/EmbedIt.js
@@ -73,7 +73,7 @@ embedit.redGifConvert = function (url, embedFunc) {
   // https://github.com/ubershmekel/redditp/issues/138
   // Redgifs isn't allowing CORS requests to others.
   // access-control-allow-origin: https://www.redgifs.com
-  const iframeUrl = 'https://www.redgifs.com/ifr/' + name + (rp.settings.sound ? "#sound" : "");
+  const iframeUrl = 'https://www.redgifs.com/ifr/' + "?link=false&loop=" + !rp.settings.shouldAutoNextSlide + "&sound=" + rp.settings.sound;
   embedFunc($('<iframe src="' + iframeUrl + '" frameborder="0" scrolling="no" width="100%" height="100%" allowfullscreen="" style="position:absolute;"></iframe>'));
   return true;
 };

--- a/js/script.js
+++ b/js/script.js
@@ -249,7 +249,7 @@ $(function () {
             if (rp.settings.sound) {
                 iframeTags[0].contentWindow.postMessage("soundOn", "*");
             } else {
-                iframe.contentWindow.postMessage("soundOff", "*");
+                iframeTags[0].contentWindow.postMessage("soundOff", "*");
             }
         } else {
             console.log(iframeTags);

--- a/js/script.js
+++ b/js/script.js
@@ -17,7 +17,7 @@ rp.settings = {
     timeToNextSlide: 6 * 1000,
     cookieDays: 300,
     nsfw: true,
-    sound: false
+    sound: false,
 };
 
 rp.session = {
@@ -231,6 +231,17 @@ $(function () {
             audioTags[0].muted = !rp.settings.sound;
         } else {
             console.log(audioTags);
+        }
+        var iframes = document.getElementsByTagName('iframe'); // turn sound on/off in embeds. This only works if the embed implements the soundOn/soundOff postMessage API.
+        for (var index=0, len = iframes.length; index < len; index++) { // we have to iterate over all the iframes because some extensions add extra ones to the page—this would break if e.g. tridactyl was installed.
+          const iframe = iframes[index];
+          if (iframe.src.indexOf("redgifs") > -1) { // mostly for redgifs
+            if (rp.settings.sound) {
+              iframe.contentWindow.postMessage("soundOn", "*");
+            } else {
+              iframe.contentWindow.postMessage("soundOff", "*");
+            }
+          }
         }
     };
 

--- a/js/script.js
+++ b/js/script.js
@@ -92,12 +92,13 @@ $(function () {
     //setupFadeoutOnIdle();
     
     window.onmessage = function(message) {
-      if (message.data === "gfy_enhanced_api") {
-        rp.session.gfy_enhanced_api = true;
-      }
-      if (message.data === "gfy_ended") {
-        // next image
-      }
+        if (message.data === "gfy_enhanced_api") {
+          rp.session.gfy_enhanced_api = true;
+        }
+        if (message.data === "gfy_ended") {
+            if (rp.settings.shouldAutoNextSlide)
+                nextSlide();
+        }
     }
     
     var getNextSlideIndex = function (currentIndex) {
@@ -243,16 +244,15 @@ $(function () {
         } else {
             console.log(audioTags);
         }
-        var iframes = document.getElementsByClassName('iframe'); // turn sound on/off in embeds. This only works if the embed implements the soundOn/soundOff postMessage API.
-        for (var index=0, len = iframes.length; index < len; index++) { // we have to iterate over all the iframes because some extensions add extra ones to the page—this would break if e.g. tridactyl was installed.
-          const iframe = iframes[index];
-          if (iframe.src.indexOf("redgifs") > -1) { // mostly for redgifs
+        var iframeTags = document.getElementsByClassName('gfyframe'); // turn sound on/off in embeds. This only works if the embed implements the soundOn/soundOff postMessage API.
+        if (iframeTags.length === 1) {
             if (rp.settings.sound) {
-              iframe.contentWindow.postMessage("soundOn", "*");
+                iframeTags[0].contentWindow.postMessage("soundOn", "*");
             } else {
-              iframe.contentWindow.postMessage("soundOff", "*");
+                iframe.contentWindow.postMessage("soundOff", "*");
             }
-          }
+        } else {
+            console.log(iframeTags);
         }
     };
 

--- a/js/script.js
+++ b/js/script.js
@@ -36,7 +36,9 @@ rp.session = {
 
     foundOneImage: false,
 
-    loadingNextImages: false
+    loadingNextImages: false,
+    
+    gfy_enhanced_api: false,
 };
 
 // Variable to store the images we need to set as background
@@ -88,7 +90,16 @@ $(function () {
     // this fadeout was really inconvenient on mobile phones
     // and instead the minimize buttons should be used.
     //setupFadeoutOnIdle();
-
+    
+    window.onmessage = function(message) {
+      if (message.data === "gfy_enhanced_api") {
+        rp.session.gfy_enhanced_api = true;
+      }
+      if (message.data === "gfy_ended") {
+        // next image
+      }
+    }
+    
     var getNextSlideIndex = function (currentIndex) {
         if (!rp.settings.nsfw) {
             // Skip any nsfw if you should
@@ -232,7 +243,7 @@ $(function () {
         } else {
             console.log(audioTags);
         }
-        var iframes = document.getElementsByTagName('iframe'); // turn sound on/off in embeds. This only works if the embed implements the soundOn/soundOff postMessage API.
+        var iframes = document.getElementsByClassName('iframe'); // turn sound on/off in embeds. This only works if the embed implements the soundOn/soundOff postMessage API.
         for (var index=0, len = iframes.length; index < len; index++) { // we have to iterate over all the iframes because some extensions add extra ones to the page—this would break if e.g. tridactyl was installed.
           const iframe = iframes[index];
           if (iframe.src.indexOf("redgifs") > -1) { // mostly for redgifs

--- a/js/script.js
+++ b/js/script.js
@@ -716,6 +716,13 @@ $(function () {
             });
         }
     };
+    
+    var startPlayingGfy = function (gfyframe) {
+        if (rp.settings.shouldAutoNextSlide && rp.session.gfy_enhanced_api) {
+            // If gfy_enhanced_api is false, then there's no way for it to detect when the video ends, and it should just use the timeout
+            clearTimeout(rp.session.nextSlideTimeoutId);
+        }
+    }
 
     //
     // Slides the background photos
@@ -741,6 +748,11 @@ $(function () {
             var maybeVid = $('video');
             if (maybeVid.length > 0) {
                 startPlayingVideo(maybeVid);
+            }
+            
+            var maybeGfy = $('.gfyframe');
+            if (maybeGfy.length > 0) {
+              startPlayingGfy(maybeGfy); // I don't think I need to actually duplicate the code from above like this, but this might make things easier to refactor later.
             }
         });
     };


### PR DESCRIPTION
- Made embedit.redGifConvert automatically add #sound fragment when sound is on. No effect on users not using the userscript.
- Extended updateSound method in script.js to post the soundOn/soundOff messages to embedded redgifs iframes when toggled.
I know I said it exceeded my abilities, but it turned out it did not.

I have made [a userscript](https://greasyfork.org/en/scripts/486812-redgifs-iframe-sound-helper), which works with ViolentMonkey on Firefox (likely works on some other configurations, but does _not_ work with Greasemonkey on Firefox), which provides a teeny tiny little API to allow sites to control RedGIFs embeds for users via URL manipulation and/or message passing.

The main purpose of this is to allow the sound checkbox to actually affect embedded redgifs images. This is beneficial to many users, such as users with disabilities who may have a hard time manipulating the mouse to enable sound for each individual image.

Users who do not have the script installed will notice no difference. Users who do have the script installed should have a seamless experience.

This should work so long as RedGIFs does not maliciously block it from working.
