### PR TITLE
Stop/Resume Slideshow When User Leaves The Tab

### DIFF
--- a/js/EmbedIt.js
+++ b/js/EmbedIt.js
@@ -74,7 +74,7 @@ embedit.redGifConvert = function (url, embedFunc) {
   // Redgifs isn't allowing CORS requests to others.
   // access-control-allow-origin: https://www.redgifs.com
   const iframeUrl = 'https://www.redgifs.com/ifr/' + name;
-  embedFunc($('<iframe src="' + iframeUrl + '" frameborder="0" scrolling="no" width="100%" height="100%" allowfullscreen="" style="position:absolute;"></iframe>'));
+  embedFunc($('<iframe class="gfyframe" src="' + iframeUrl + '" frameborder="0" scrolling="no" width="100%" height="100%" allowfullscreen="" style="position:absolute;"></iframe>'));
   return true;
 };
 

--- a/js/EmbedIt.js
+++ b/js/EmbedIt.js
@@ -74,7 +74,7 @@ embedit.redGifConvert = function (url, embedFunc) {
   // Redgifs isn't allowing CORS requests to others.
   // access-control-allow-origin: https://www.redgifs.com
   const iframeUrl = 'https://www.redgifs.com/ifr/' + name;
-  embedFunc($('<iframe class="gfyframe" src="' + iframeUrl + '" frameborder="0" scrolling="no" width="100%" height="100%" allowfullscreen="" style="position:absolute;"></iframe>'));
+  embedFunc($('<iframe class="gfyframe" src="' + iframeUrl + '" saved-src="' + iframeUrl + '" frameborder="0" scrolling="no" width="100%" height="100%" allowfullscreen="" style="position:absolute;"></iframe>'));
   return true;
 };
 

--- a/js/script.js
+++ b/js/script.js
@@ -138,7 +138,8 @@ $(function () {
     }
     
     document.addEventListener("visibilitychange", (vcEvent) => {
-        console.log(document.visibilityState);
+        if (!rp.session.pauseOnTabAway)
+            return;
         if (document.visibilityState === "visible") {
             becomeVisible(vcEvent);
         } else {

--- a/js/script.js
+++ b/js/script.js
@@ -38,6 +38,8 @@ rp.session = {
 
     loadingNextImages: false,
     
+    gfy_enhanced_api: false,
+    
     pauseOnTabAway: true,
 };
 
@@ -91,6 +93,16 @@ $(function () {
     // and instead the minimize buttons should be used.
     //setupFadeoutOnIdle();
     
+    window.onmessage = function(message) {
+        if (message.data === "gfy_enhanced_api") {
+          rp.session.gfy_enhanced_api = true;
+        }
+        if (message.data === "gfy_ended") {
+            if (rp.settings.shouldAutoNextSlide)
+                nextSlide();
+        }
+    }
+    
     var becomeInvisible = function(evt) {
         if (rp.settings.shouldAutoNextSlide)
             clearTimeout(rp.session.nextSlideTimeoutId);
@@ -117,6 +129,8 @@ $(function () {
         if (maybeGfy.length > 0) {
             console.log("found a gfy, pausing it");
             playVideo(maybeGfy[0]);
+            if (rp.session.gfy_enhanced_api)
+                return;
         }
         console.log("Starting slideshow again");
         resetNextSlideTimer();
@@ -743,8 +757,11 @@ $(function () {
             elem.play();
         }
         else if (elem.tagName === "IFRAME" && elem.classList.contains("gfyframe")) {
-            elem.contentWindow.postMessage("pause", "*");
-            // todo: make this work without the third-party userscript by setting elem.src = ""
+            if (rp.session.gfy_enhanced_api)
+                elem.contentWindow.postMessage("pause", "*");
+            else {
+                
+            }
         }
     }
     
@@ -753,8 +770,11 @@ $(function () {
             elem.pause();
         }
         else if (elem.tagName === "IFRAME" && elem.classList.contains("gfyframe")) {
-            elem.contentWindow.postMessage("play", "*");
-            // todo: make this work without the third-party userscript by setting elem.src = ""
+            if (rp.session.gfy_enhanced_api)
+                elem.contentWindow.postMessage("play", "*");
+            else {
+                
+            }
         }
     }
 

--- a/js/script.js
+++ b/js/script.js
@@ -694,6 +694,26 @@ $(function () {
             });
         }
     };
+    
+    var pauseVideo = function(elem) {
+        if (elem.tagName === "VIDEO") {
+            elem.play();
+        }
+        else if (elem.tagName === "IFRAME" && elem.classList.contains("gfyframe")) {
+            
+        }
+    }
+    
+    var playVideo = function(elem) {
+        if (elem.tagName === "VIDEO") {
+            elem.pause();
+        }
+        else if (elem.tagName === "IFRAME" && elem.classList.contains("gfyframe")) {
+            
+        }
+    }
+    
+    class
 
     //
     // Slides the background photos

--- a/js/script.js
+++ b/js/script.js
@@ -17,7 +17,8 @@ rp.settings = {
     timeToNextSlide: 6 * 1000,
     cookieDays: 300,
     nsfw: true,
-    sound: false
+    sound: false,
+    pauseOnTabAway: true,
 };
 
 rp.session = {
@@ -39,8 +40,6 @@ rp.session = {
     loadingNextImages: false,
     
     gfy_enhanced_api: false,
-    
-    pauseOnTabAway: true,
 };
 
 // Variable to store the images we need to set as background
@@ -138,7 +137,7 @@ $(function () {
     }
     
     document.addEventListener("visibilitychange", (vcEvent) => {
-        if (!rp.session.pauseOnTabAway)
+        if (!rp.settings.pauseOnTabAway)
             return;
         if (document.visibilityState === "visible") {
             becomeVisible(vcEvent);

--- a/js/script.js
+++ b/js/script.js
@@ -700,7 +700,8 @@ $(function () {
             elem.play();
         }
         else if (elem.tagName === "IFRAME" && elem.classList.contains("gfyframe")) {
-            
+            elem.contentWindow.postMessage("pause", "*");
+            // todo: make this work without the third-party userscript by setting elem.src = ""
         }
     }
     
@@ -709,7 +710,8 @@ $(function () {
             elem.pause();
         }
         else if (elem.tagName === "IFRAME" && elem.classList.contains("gfyframe")) {
-            
+            elem.contentWindow.postMessage("play", "*");
+            // todo: make this work without the third-party userscript by setting elem.src = ""
         }
     }
     

--- a/js/script.js
+++ b/js/script.js
@@ -36,7 +36,9 @@ rp.session = {
 
     foundOneImage: false,
 
-    loadingNextImages: false
+    loadingNextImages: false,
+    
+    pauseOnTabAway: true,
 };
 
 // Variable to store the images we need to set as background
@@ -88,6 +90,47 @@ $(function () {
     // this fadeout was really inconvenient on mobile phones
     // and instead the minimize buttons should be used.
     //setupFadeoutOnIdle();
+    
+    var becomeInvisible = function(evt) {
+        if (rp.settings.shouldAutoNextSlide)
+            clearTimeout(rp.session.nextSlideTimeoutId);
+        var maybeVid = $("video");
+        if (maybeVid.length > 0) {
+            pauseVideo(maybeVid[0]);
+        }
+        
+        var maybeGfy = $(".gfyframe");
+        if (maybeGfy.length > 0) {
+            console.log("found a gfy, pausing it");
+            pauseVideo(maybeGfy[0]);
+        }
+    }
+    
+    var becomeVisible = function(evt) {
+        var maybeVid = $("video");
+        if (maybeVid.length > 0) {
+            playVideo(maybeVid[0]);
+            return;
+        }
+        
+        var maybeGfy = $(".gfyframe");
+        if (maybeGfy.length > 0) {
+            console.log("found a gfy, pausing it");
+            playVideo(maybeGfy[0]);
+        }
+        console.log("Starting slideshow again");
+        resetNextSlideTimer();
+        console.log("yaaaay");
+    }
+    
+    document.addEventListener("visibilitychange", (vcEvent) => {
+        console.log(document.visibilityState);
+        if (document.visibilityState === "visible") {
+            becomeVisible(vcEvent);
+        } else {
+            becomeInvisible(vcEvent);
+        }
+    });
 
     var getNextSlideIndex = function (currentIndex) {
         if (!rp.settings.nsfw) {

--- a/js/script.js
+++ b/js/script.js
@@ -760,7 +760,7 @@ $(function () {
             if (rp.session.gfy_enhanced_api)
                 elem.contentWindow.postMessage("pause", "*");
             else {
-                
+                elem.src = "";
             }
         }
     }
@@ -773,7 +773,7 @@ $(function () {
             if (rp.session.gfy_enhanced_api)
                 elem.contentWindow.postMessage("play", "*");
             else {
-                
+                elem.src = elem.getAttribute("saved-src");
             }
         }
     }

--- a/js/script.js
+++ b/js/script.js
@@ -714,8 +714,6 @@ $(function () {
             // todo: make this work without the third-party userscript by setting elem.src = ""
         }
     }
-    
-    class
 
     //
     // Slides the background photos


### PR DESCRIPTION
Simple enough change; adds an `eventListener` for a `visibilitychange`. If the user just left the current tab, then (a) checks if auto-next is on, and if so, clears the timeout, and (b) pauses any current video playing. When the user returns to the tab, it (a) checks if auto-next is on, and if so, resets the timeout, and (b) resumes any current video playing.

It can even pause/resume gfycat-style iframes; it accomplishes this two ways.

First, it checks if the custom userscript I made is present. If it is, it can just send an appropriate play or pause signal to the iframe and the userscript will obey.

If it isn't, then it "pauses" by blanking out the `src` attribute and "plays" by restoring it. This does mean that, in this case, state such as place in the video and whether audio is on is lost, but since gfycat-style vids tend to be pretty short, and enabling/disabling audio is already pretty finicky, I think that's a fair tradeoff.

**TODO**: All this behavior is controlled by `rp.settings.pauseOnTabAway`, which is set to `true` by default. I have not yet added a way for the user to change it; looking for feedback from the community.