### PR TITLE
Use g to skip non-galleries too

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -874,7 +874,7 @@ $(function () {
     var skipGallery = async function () { 
         photo = rp.photos[rp.session.activeIndex];  
         if (!photo.data.is_gallery){
-            return
+            nextSlide();
         }
         var skipCount = (photo.galleryTotal - photo.galleryItem)+1
         nextSlide(skipCount)

--- a/js/script.js
+++ b/js/script.js
@@ -875,6 +875,7 @@ $(function () {
         photo = rp.photos[rp.session.activeIndex];  
         if (!photo.data.is_gallery){
             nextSlide();
+            return;
         }
         var skipCount = (photo.galleryTotal - photo.galleryItem)+1
         nextSlide(skipCount)


### PR DESCRIPTION
Currently, pressing g on the keyboard skips the current gallery, but does nothing on non-galleries (which is intended behavior). I propose, for a smoother user experience, to have g behave like a normal button to skip slides on normal posts, so that pressing g always moves to the next post (whether the current is a gallery or not).